### PR TITLE
Several bugfixes: correct and uniq subgroups, and more...

### DIFF
--- a/cg-make-snapshot.sh
+++ b/cg-make-snapshot.sh
@@ -151,7 +151,7 @@ function login () {
 function getSubgroups () {
     local group="$1"
     wget --quiet --load-cookies "$COOKIE_FILE" -O - "${BASE_URL}/${group}/" \
-        | grep -E --only-matching "href=\"/${group}\+\w+" \
+        | grep -E --only-matching "href=\"/${group}\+[^\"]+" \
             | cut -d '"' -f 2 | cut -d '/' -f 2 \
                 | grep "$group" | sort | uniq
 }
@@ -168,6 +168,7 @@ function getSubgroups () {
 function mirrorGroup () {
     local group="$1"
     local include_path="/${group},/groups/${group},/assets"
+    local url="${BASE_URL}/${group}/"
 
     if [ 1 -eq $SUBGROUP ]; then
         echo "Finding subgroups for $group..."
@@ -175,6 +176,7 @@ function mirrorGroup () {
         echo "Mirroring group $group with all subgroups: ${subgroups[@]} "
         for subgroup in ${subgroups[@]}; do
             include_path="${include_path},/${subgroup},/groups/${subgroup}"
+            url="${url} ${BASE_URL}/${subgroup}"
         done
     else 
       echo "Mirroring group $group..."
@@ -184,7 +186,7 @@ function mirrorGroup () {
         --include "$include_path" --convert-links --retry-connrefused \
         --reject "edit.html" \
         --directory-prefix "${DOWNLOAD_DIR}" \
-        --page-requisites --html-extension "${BASE_URL}/${group}/"
+        --page-requisites --html-extension ${url}
 }
 
 function main () {

--- a/cg-make-snapshot.sh
+++ b/cg-make-snapshot.sh
@@ -182,7 +182,7 @@ function mirrorGroup () {
 
     $DRY_RUN wget --load-cookies "$COOKIE_FILE" --mirror \
         --include "$include_path" --convert-links --retry-connrefused \
-        --reject-regex "/edit\.html" \
+        --reject "edit.html" \
         --directory-prefix "${DOWNLOAD_DIR}" \
         --page-requisites --html-extension "${BASE_URL}/${group}/"
 }


### PR DESCRIPTION
I hope you do not mind that I did not split this up into several PRs (not much time, and I found more and more minor bugs while fixing one ;)

This fixes several minor issues in order of occurence in the diff at right hand side below:
1. `getSubgroups` was missing several "older" subgroups if no files of these were in the most current timeline
2. Subgroups were not uniq: A `sort` was missing
3. Having subsequent wget call for each subgroup had the problem that links for files in subgroups listed in main group did not get the link correctly rewritten by wget. I now have one single wget with include_path adjusted
4. URLs with `edit.html` were downloaded. This is of no value here.
