### PR TITLE
fixes for Alpine Linux and for the subgroup option

### DIFF
--- a/cg-make-snapshot.sh
+++ b/cg-make-snapshot.sh
@@ -287,9 +287,8 @@ mirrorGroup () {
     if [ 1 -eq $SUBGROUP ]; then
         echo "Finding subgroups for $group..."
         read -r -a subgroups <<< $(getSubgroups "$group")
-        echo "Mirroring group $group with all subgroups"
+        echo "Mirroring group $group with all subgroups: ${subgroups[@]} "
         for subgroup in ${subgroups[@]}; do
-            echo $subgroup
             include_path="${include_path},/${subgroup},/groups/${subgroup}"
             url="${url} ${BASE_URL}/${subgroup}"
         done


### PR DESCRIPTION
Hello,
I think the subgroups option was broken.
At least it didn't work for me either on arch or alpine linux.
Now it seems to be working :)
The other changes are related to the busybox versions of mktemp and grep working a bit different.
Now they should work with both the busybox and GNU variant.

